### PR TITLE
Introduce EnhancedSplash / EnhancedHurtRadius toggle for StationaryPawns

### DIFF
--- a/Classes/WeaponSettings.uc
+++ b/Classes/WeaponSettings.uc
@@ -17,6 +17,7 @@ var config bool bReplaceWarheadLauncher;
 var config bool  bEnableEnhancedSplash;
 var config bool  bEnableEnhancedSplashBio;
 var config bool  bEnableEnhancedSplashCombo;
+var config bool  bEnhancedSplashIgnoreStationaryPawns;
 var config float SplashMaxDiffraction;
 var config float SplashMinDiffractionDistance;
 


### PR DESCRIPTION
 - Allows togglable reversion of damage handling for scriptedpawn actors, e.g. Assault FortStandard (objectives) / TeamCannons, while still utilising the EnhancedHurtRadius function for other actors.