### PR TITLE
Added More Weapon Settings

### DIFF
--- a/Classes/ST_BioGlob.uc
+++ b/Classes/ST_BioGlob.uc
@@ -77,6 +77,20 @@ state OnSurface
 			return;
 		GotoState('Exploding');
 	}
+
+	function BeginState()
+	{
+		wallTime = 3.8;
+		
+		MyFear = Spawn(class'BioFear');
+		if ( Mover(Base) != None )
+		{
+			BaseOffset = VSize(Location - Base.Location);
+			SetTimer(0.2, true);
+		}
+		else 
+			SetTimer(wallTime, false);
+	}
 }
 
 defaultproperties

--- a/Classes/ST_BioSplash.uc
+++ b/Classes/ST_BioSplash.uc
@@ -17,6 +17,24 @@ auto state Flying
 	}
 }
 
+state OnSurface
+{
+	function BeginState()
+	{
+		wallTime = 3.8;
+		
+		MyFear = Spawn(class'BioFear');
+		if ( Mover(Base) != None )
+		{
+			BaseOffset = VSize(Location - Base.Location);
+			SetTimer(0.2, true);
+		}
+		else 
+			SetTimer(wallTime, false);
+	}
+
+}
+
 defaultproperties
 {
      speed=300.000000

--- a/Classes/ST_PlasmaSphere.uc
+++ b/Classes/ST_PlasmaSphere.uc
@@ -15,7 +15,46 @@ simulated function PostBeginPlay()
 		ForEach AllActors(Class'ST_Mutator', STM)
 			break;
 	}
+	Speed = STM.WeaponSettings.PulseSphereSpeed;
+	DrawScale=0.120000;
 	Super.PostBeginPlay();
+}
+
+simulated function Explode(vector HitLocation, vector HitNormal)
+{
+	if ( !bExplosionEffect )
+	{
+		if ( Role == ROLE_Authority )
+			BlowUp(HitLocation);
+		bExplosionEffect = true;
+		if ( !Level.bHighDetailMode || bHitPawn || Level.bDropDetail )
+		{
+			if ( bExploded )
+			{
+				Destroy();
+				return;
+			}
+			else
+				DrawScale = 0.2;
+		}
+		else
+			DrawScale = 0.2;
+
+	    LightType = LT_Steady;
+		LightRadius = 5;
+		SetCollision(false,false,false);
+		LifeSpan = 0.5;
+		Texture = ExpType;
+		DrawType = DT_SpriteAnimOnce;
+		Style = STY_Translucent;
+		if ( Region.Zone.bMoveProjectiles && (Region.Zone.ZoneVelocity != vect(0,0,0)) )
+		{
+			bBounce = true;
+			Velocity = Region.Zone.ZoneVelocity;
+		}
+		else
+			SetPhysics(PHYS_None);
+	}
 }
 
 simulated function ProcessTouch (Actor Other, vector HitLocation)

--- a/Classes/ST_ShockProj.uc
+++ b/Classes/ST_ShockProj.uc
@@ -11,6 +11,9 @@ var ST_Mutator STM;
 // For Standstill combo Special
 var vector StartLocation;
 
+// For ShockProjectileTakeDamage
+var float Health;
+
 simulated function PostBeginPlay()
 {
 	if (ROLE == ROLE_Authority)
@@ -19,7 +22,10 @@ simulated function PostBeginPlay()
 		ForEach AllActors(Class'ST_Mutator', STM)
 			break;		// Find master :D
 	}
-
+	if (STM.WeaponSettings.ShockProjectileTakeDamage == True)
+	{
+		Health = STM.WeaponSettings.ShockProjectileHealth;
+	}
 	Super.PostBeginPlay();
 }
 
@@ -73,6 +79,22 @@ function Explode(vector HitLocation,vector HitNormal)
 		Spawn(class'ut_RingExplosion',,, HitLocation+HitNormal*8,rotator(Velocity));		
 
 	Destroy();
+}
+
+function TakeDamage( int Damage, Pawn EventInstigator, vector HitLocation, vector Momentum, name DamageType)
+{
+	if (STM.WeaponSettings.ShockProjectileTakeDamage == True)
+	{
+		if (DamageType == 'Pulsed'|| DamageType == 'Corroded')
+			{
+				Health -= Damage;
+				if (Health <= 0)
+				{
+					Spawn(class'ut_RingExplosion',,, Location + Momentum * 0.1, rotator(Momentum));
+					Destroy();
+				}
+		}
+	}
 }
 
 defaultproperties {

--- a/Classes/ST_UT_BioGel.uc
+++ b/Classes/ST_UT_BioGel.uc
@@ -50,6 +50,60 @@ function Timer()
 	Destroy();	
 }
 
+state OnSurface
+{
+	function ProcessTouch (Actor Other, vector HitLocation)
+	{
+		GotoState('Exploding');
+	}
+
+
+	function Timer()
+	{
+		if ( Mover(Base) != None )
+		{
+			WallTime -= 0.2;
+			if ( WallTime < 0.15 )
+				Global.Timer();
+			else if ( VSize(Location - Base.Location) > BaseOffset + 4 )
+				Global.Timer();
+		}
+		else
+			Global.Timer();
+	}
+	
+	function BeginState()
+	{
+		wallTime = 3.8;
+		
+		MyFear = Spawn(class'BioFear');
+		if ( Mover(Base) != None )
+		{
+			BaseOffset = VSize(Location - Base.Location);
+			SetTimer(0.2, true);
+		}
+		else
+		{
+			if (STM.WeaponSettings.BioPrimaryInstantExplosion)
+				Timer();
+			else
+				SetTimer(wallTime, false);
+		}
+	}
+
+}
+
+state Exploding
+{
+	ignores Touch, TakeDamage;
+
+	function BeginState()
+	{
+		SetTimer(0.2, False); // Make explosions after touch not random
+	}
+}
+
+
 auto state Flying
 {
 	function ProcessTouch (Actor Other, vector HitLocation) 

--- a/Classes/WeaponSettings.uc
+++ b/Classes/WeaponSettings.uc
@@ -82,6 +82,8 @@ var config float PulseSelectTime;
 var config float PulseDownTime;
 var config float PulseSphereDamage;
 var config float PulseSphereMomentum;
+var config float PulseSphereSpeed;
+var config float PulseSphereFireRate;
 var config float PulseBoltDPS;
 var config float PulseBoltMomentum;
 var config float PulseBoltMaxAccumulate;
@@ -96,6 +98,8 @@ var config float ShockProjectileDamage;
 var config float ShockProjectileHurtRadius;
 var config float ShockProjectileMomentum;
 var config bool  ShockProjectileBlockBullets;
+var config bool  ShockProjectileTakeDamage;
+var config float ShockProjectileHealth;
 var config float ShockComboDamage;
 var config float ShockComboMomentum;
 var config float ShockComboHurtRadius;
@@ -104,6 +108,7 @@ var config float BioSelectTime;
 var config float BioDownTime;
 var config float BioDamage;
 var config float BioMomentum;
+var config bool  BioPrimaryInstantExplosion; 
 var config float BioAltDamage;
 var config float BioAltMomentum;
 var config float BioHurtRadiusBase;
@@ -226,6 +231,8 @@ defaultproperties
 	PulseDownTime=0.26
 	PulseSphereDamage=20
 	PulseSphereMomentum=1.0
+	PulseSphereSpeed=1450.000000
+	PulseSphereFireRate=0.18
 	PulseBoltDPS=72
 	PulseBoltMomentum=1.0
 	PulseBoltMaxAccumulate=0.08
@@ -240,6 +247,8 @@ defaultproperties
 	ShockProjectileHurtRadius=70
 	ShockProjectileMomentum=1.0
 	ShockProjectileBlockBullets=True
+	ShockProjectileTakeDamage=False
+	ShockProjectileHealth=30
 	ShockComboDamage=165
 	ShockComboHurtRadius=250
 	ShockComboMomentum=1.0
@@ -248,6 +257,7 @@ defaultproperties
 	BioDownTime=0.333333
 	BioDamage=20
 	BioMomentum=1.0
+	BioPrimaryInstantExplosion=False
 	BioAltDamage=75
 	BioAltMomentum=1.0
 	BioHurtRadiusBase=75

--- a/Classes/WeaponSettingsRepl.uc
+++ b/Classes/WeaponSettingsRepl.uc
@@ -57,6 +57,8 @@ var float PulseSelectTime;
 var float PulseDownTime;
 var float PulseSphereDamage;
 var float PulseSphereMomentum;
+var float PulseSphereSpeed;
+var float PulseSphereFireRate;
 var float PulseBoltDPS;
 var float PulseBoltMomentum;
 var float PulseBoltMaxAccumulate;
@@ -70,6 +72,8 @@ var float ShockBeamMomentum;
 var float ShockProjectileDamage;
 var float ShockProjectileHurtRadius;
 var float ShockProjectileMomentum;
+var bool  ShockProjectileTakeDamage;
+var float ShockProjectileHealth;
 var float ShockComboDamage;
 var float ShockComboMomentum;
 var float ShockComboHurtRadius;
@@ -78,6 +82,7 @@ var float BioSelectTime;
 var float BioDownTime;
 var float BioDamage;
 var float BioMomentum;
+var bool  BioPrimaryInstantExplosion;
 var float BioAltDamage;
 var float BioAltMomentum;
 var float BioHurtRadiusBase;
@@ -173,6 +178,8 @@ replication {
 		PulseDownTime,
 		PulseSphereDamage,
 		PulseSphereMomentum,
+		PulseSphereSpeed,
+		PulseSphereFireRate,
 		PulseBoltDPS,
 		PulseBoltMomentum,
 		PulseBoltMaxAccumulate,
@@ -186,6 +193,8 @@ replication {
 		ShockProjectileDamage,
 		ShockProjectileHurtRadius,
 		ShockProjectileMomentum,
+		ShockProjectileTakeDamage,
+		ShockProjectileHealth,
 		ShockComboDamage,
 		ShockComboMomentum,
 		ShockComboHurtRadius,
@@ -194,6 +203,7 @@ replication {
 		BioDownTime,
 		BioDamage,
 		BioMomentum,
+		BioPrimaryInstantExplosion,
 		BioAltDamage,
 		BioAltMomentum,
 		BioHurtRadiusBase,
@@ -482,6 +492,8 @@ function InitFromWeaponSettings(WeaponSettings S) {
 	PulseDownTime = S.PulseDownTime;
 	PulseSphereDamage = S.PulseSphereDamage;
 	PulseSphereMomentum = S.PulseSphereMomentum;
+	PulseSphereSpeed = S.PulseSphereSpeed;
+	PulseSphereFireRate = S.PulseSphereFireRate;
 	PulseBoltDPS = S.PulseBoltDPS;
 	PulseBoltMomentum = S.PulseBoltMomentum;
 	PulseBoltMaxAccumulate = S.PulseBoltMaxAccumulate;
@@ -495,6 +507,8 @@ function InitFromWeaponSettings(WeaponSettings S) {
 	ShockProjectileDamage = S.ShockProjectileDamage;
 	ShockProjectileHurtRadius = S.ShockProjectileHurtRadius;
 	ShockProjectileMomentum = S.ShockProjectileMomentum;
+	ShockProjectileTakeDamage = S.ShockProjectileTakeDamage;
+	ShockProjectileHealth = S.ShockProjectileHealth;
 	ShockComboDamage = S.ShockComboDamage;
 	ShockComboMomentum = S.ShockComboMomentum;
 	ShockComboHurtRadius = S.ShockComboHurtRadius;
@@ -503,6 +517,7 @@ function InitFromWeaponSettings(WeaponSettings S) {
 	BioDownTime = S.BioDownTime;
 	BioDamage = S.BioDamage;
 	BioMomentum = S.BioMomentum;
+	BioPrimaryInstantExplosion = S.BioPrimaryInstantExplosion;
 	BioAltDamage = S.BioAltDamage;
 	BioAltMomentum = S.BioAltMomentum;
 	BioHurtRadiusBase = S.BioHurtRadiusBase;
@@ -637,6 +652,8 @@ defaultproperties
 	PulseDownTime=0.26
 	PulseSphereDamage=20
 	PulseSphereMomentum=1.0
+	PulseSphereSpeed=1450.000000
+	PulseSphereFireRate=0.18
 	PulseBoltDPS=72
 	PulseBoltMomentum=1.0
 	PulseBoltMaxAccumulate=0.08
@@ -650,6 +667,8 @@ defaultproperties
 	ShockProjectileDamage=55
 	ShockProjectileHurtRadius=70
 	ShockProjectileMomentum=1.0
+	ShockProjectileTakeDamage=False
+	ShockProjectileHealth=30
 	ShockComboDamage=165
 	ShockComboHurtRadius=250
 	ShockComboMomentum=1.0
@@ -658,6 +677,7 @@ defaultproperties
 	BioDownTime=0.333333
 	BioDamage=20
 	BioMomentum=1.0
+	BioPrimaryInstantExplosion=False
 	BioAltDamage=75
 	BioAltMomentum=1.0
 	BioHurtRadiusBase=75


### PR DESCRIPTION
Pulse Gun normal fire now has a PulseSphereFireRate setting to control the Rate of Fire and PulseSphereSpeed to control the Speed of PulseSphere projectiles. Additionally, PulseSphere projectiles and Explosions have a reduced DrawScale.

Bio Rifle primary Bio Gel projectiles will explode on impact and cause splash damage.

Shock Balls can now take damage if ShockProjectileTakeDamage=True and can be destroyed by Pulse Gun and Bio Rifle projectiles. ShockProjectileHealth can be configured.