### PR TITLE
Improved Client Animations for Shock, Flak, and Sniper. Set defaults to False

### DIFF
--- a/Classes/ClientSettings.uc
+++ b/Classes/ClientSettings.uc
@@ -502,12 +502,12 @@ defaultproperties
 	HitMarkerDecayExponent=5.0
 	HitMarkerSource=HMSRC_Server
 	bUseCrosshairFactory=False
-	bBioUseClientSideAnimations=True
-	bShockUseClientSideAnimations=True
-	bPulseUseClientSideAnimations=True
-	bRipperUseClientSideAnimations=True
-	bFlakUseClientSideAnimations=True
-	bSniperUseClientSideAnimations=True
+	bBioUseClientSideAnimations=False
+	bShockUseClientSideAnimations=False
+	bPulseUseClientSideAnimations=False
+	bRipperUseClientSideAnimations=False
+	bFlakUseClientSideAnimations=False
+	bSniperUseClientSideAnimations=False
 
 	MenuX=200
 	MenuY=200

--- a/Classes/ST_ShockRifle.uc
+++ b/Classes/ST_ShockRifle.uc
@@ -51,15 +51,16 @@ simulated function yModInit() {
 	CDO = CalcDrawOffsetClient();
 }
 
+
 simulated function bool ClientFire( float Value )
 {
-    if (Super.ClientFire(Value))
-    {
-		if (Role < ROLE_Authority)
-			ClientTraceFire();
-    }
-    return true;
+      if (Role < ROLE_Authority && (AmmoType == None || AmmoType.AmmoAmount > 0)) {
+          ClientTraceFire();
+      }
+
+      return Super.ClientFire(Value);
 }
+
 
 // Client-side shock beam tracing and effect spawning
 simulated function ClientTraceFire() {
@@ -144,12 +145,13 @@ simulated function ClientSpawnBeam(vector HitLocation, vector SmokeLocation) {
 		bbPlayer(Owner).xxClientDemoFix(None, class'ShockBeam', SmokeLocation, , , SmokeRotation, , , DVector/NumPoints, NumPoints-1);
 }
 
-simulated function PlayAltFiring()
+simulated function bool ClientAltFire( float Value )
 {
-	Super.PlayAltFiring();
+      if (Role < ROLE_Authority && (AmmoType == None || AmmoType.AmmoAmount > 0)) {
+          ClientSpawnAltProjectileEffects();
+      }
 
-	if ((Role < ROLE_Authority) && GetWeaponSettings().ShockProjectileCompensatePing)
-			ClientSpawnAltProjectileEffects();
+      return Super.ClientAltFire(Value);
 }
 
 simulated function ClientSpawnAltProjectileEffects() {
@@ -183,8 +185,11 @@ function TraceFire(float Accuracy) {
 	local vector HitLocation, HitNormal, StartTrace, EndTrace, X,Y,Z;
 	local actor Other;
 	local Pawn PawnOwner;
+	local bbPlayer bbP;
 
 	PawnOwner = Pawn(Owner);
+
+	bbP = bbPlayer(PawnOwner);
 
 	Owner.MakeNoise(PawnOwner.SoundDampening);
 	GetAxes(PawnOwner.ViewRotation,X,Y,Z);
@@ -344,6 +349,18 @@ simulated function TweenDown() {
 		TweenAnim( AnimSequence, AnimFrame * GetWeaponSettings().ShockDownTime );
 	else
 		PlayAnim('Down', GetWeaponSettings().ShockDownAnimSpeed(), TweenTime);
+}
+
+// Prevents shooting on its own on reload
+// Default it would remember that you pressed fire while its reloading
+state ClientFiring {
+	simulated function bool ClientFire(float Value) {
+		return false;
+	}
+
+	simulated function bool ClientAltFire(float Value) {
+		return false;
+	}
 }
 
 // Compatibility between client and server logic

--- a/Classes/ST_UT_FlakCannon.uc
+++ b/Classes/ST_UT_FlakCannon.uc
@@ -149,24 +149,20 @@ function AltFire(float Value)
     }    
 }
 
-simulated function bool ClientFire( float Value )
-{
-	if (Super.ClientFire(Value))
+state ClientFiring {
+	simulated function BeginState()
 	{
 		if (Role < ROLE_Authority)
 			SpawnClientSideChunks();
 	}
-	return true;
 }
 
-simulated function bool ClientAltFire( float Value )
-{
-	if (Super.ClientAltFire(Value))
+state ClientAltFiring {
+	simulated function BeginState()
 	{
 		if (Role < ROLE_Authority)
 			SpawnClientSideSlug();
 	}
-	return true;
 }
 
 simulated function SpawnClientSideChunks()

--- a/Classes/WeaponSettings.uc
+++ b/Classes/WeaponSettings.uc
@@ -203,9 +203,9 @@ defaultproperties
 	bEnableEnhancedSplashBio=False
 	bEnableEnhancedSplashShockCombo=False
 	bEnableEnhancedSplashShockProjectile=False
-	bEnableEnhancedSplashRipperSecondary=True
-	bEnableEnhancedSplashFlakSlug=True
-	bEnableEnhancedSplashRockets=True
+	bEnableEnhancedSplashRipperSecondary=False
+	bEnableEnhancedSplashFlakSlug=False
+	bEnableEnhancedSplashRockets=False
 	SplashMaxDiffraction=0.5
 	SplashMinDiffractionDistance=50.0
 
@@ -355,7 +355,7 @@ defaultproperties
 
 	bEnableSubTickCompensation=False
 	
-	PingCompensationMax=150
+	PingCompensationMax=200
 
 	bEnableAnimationAdaptiveHeadHitbox=False
 

--- a/Classes/WeaponSettingsRepl.uc
+++ b/Classes/WeaponSettingsRepl.uc
@@ -812,7 +812,7 @@ defaultproperties
 	
 	bEnableSubTickCompensation=False
 	
-	PingCompensationMax=150
+	PingCompensationMax=200
 
 	bEnableAnimationAdaptiveHeadHitbox=False
 


### PR DESCRIPTION
- Shock Rifle restore state ClientFiring to prevent firing on reload. Add checks to ClientFire and ClientAltFire to minimize desync
- Sniper restore Client Side Animations to the previous working version
- Flak shift Client Side Animations to BeginState in ClientFiring and ClientAltFiring to minimize desync on the client
- Client Side Animations settings defaults set to False
- bEnableEnhancedSplash settings for Rockets, Flak, and Ripper defaults set to False